### PR TITLE
feat: generate fallback `any` when no properties are specified

### DIFF
--- a/src/schema-file.ts
+++ b/src/schema-file.ts
@@ -106,6 +106,8 @@ export class SchemaFile extends ModuleBuilder<NamespacedZodOptions> {
               element.mapProperties.value,
               schema,
             )})`;
+          } else {
+            yield `${z()}.any()`;
           }
 
           if (element.mapProperties) {


### PR DESCRIPTION
In the event there are no `properties` or `additionalProperties`, the generator just declares the Schema but doesn't provide a validator.

To avoid breaking the generated code, a catch-all is added that falls back to z.any() when there are no properties in an object type definition.

It looks like the snapshots rely on the IL sample in the main basketry repo to be updated.
This PR does not update the IL sample.